### PR TITLE
Support data access via env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /test.sh
 /userdata.yaml
 .DS_Store
+*.pyc
+/__pycache__


### PR DESCRIPTION
This patch adds support for accessing data via environment variables instead of directly with `vmtoolsd`. This is to support simulated testing with the vCenter simulator.

To use this datasource with environment variables simply define `VMX_GUESTINFO=1` and then define environment variables for keys with the `VMX_GUESTINFO_` prefix, like so:

```text
"guestinfo.userdata"          -> "VMX_GUESTINFO_USERDATA"
"guestinfo.userdata.encoding" -> "VMX_GUESTINFO_USERDATA_ENCODING"
```

cc @dougm @imikushin 