### PR TITLE
Use vmware-rpctool instead of vmtoolsd for performance reasons

### DIFF
--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -38,7 +38,7 @@ import netifaces
 
 LOG = logging.getLogger(__name__)
 NOVAL = "No value found"
-VMTOOLSD = find_executable("vmtoolsd")
+VMWARE_RPCTOOL = find_executable("vmware-rpctool")
 VMX_GUESTINFO = "VMX_GUESTINFO"
 
 
@@ -94,7 +94,7 @@ class DataSourceVMwareGuestInfo(sources.DataSource):
     def __init__(self, sys_cfg, distro, paths, ud_proc=None):
         sources.DataSource.__init__(self, sys_cfg, distro, paths, ud_proc)
         if not get_data_access_method():
-            LOG.error("Failed to find vmtoolsd")
+            LOG.error("Failed to find vmware-rpctool")
 
     def get_data(self):
         """
@@ -107,7 +107,7 @@ class DataSourceVMwareGuestInfo(sources.DataSource):
         such as calling persist_instance_data.
         """
         if not get_data_access_method():
-            LOG.error("vmtoolsd is required to fetch guestinfo value")
+            LOG.error("vmware-rpctool is required to fetch guestinfo value")
             return False
 
         # Get the metadata.
@@ -245,10 +245,10 @@ def get_guestinfo_value(key):
         else:
             return val
 
-    if data_access_method == VMTOOLSD:
+    if data_access_method == VMWARE_RPCTOOL:
         try:
             (stdout, stderr) = util.subp(
-                [VMTOOLSD, "--cmd", "info-get guestinfo." + key])
+                [VMWARE_RPCTOOL, "info-get guestinfo." + key])
             if stderr == NOVAL:
                 LOG.debug("No value found for key %s", key)
             elif not stdout:
@@ -517,8 +517,8 @@ def get_host_info():
 def get_data_access_method():
     if os.environ.get(VMX_GUESTINFO, ""):
         return VMX_GUESTINFO
-    if VMTOOLSD:
-        return VMTOOLSD
+    if VMWARE_RPCTOOL:
+        return VMWARE_RPCTOOL
     return None
 
 

--- a/dscheck_VMwareGuestInfo.sh
+++ b/dscheck_VMwareGuestInfo.sh
@@ -41,13 +41,13 @@ if [ -n "${VMX_GUESTINFO}" ]; then
   fi
 fi
 
-if ! command -v vmtoolsd >/dev/null 2>&1; then
+if ! command -v vmware-rpctool >/dev/null 2>&1; then
   exit 1
 fi
 
-if { vmtoolsd --cmd "info-get guestinfo.metadata" || \
-     vmtoolsd --cmd "info-get guestinfo.userdata" || \
-     vmtoolsd --cmd "info-get guestinfo.vendordata"; } >/dev/null 2>&1; then
+if { vmware-rpctool "info-get guestinfo.metadata" || \
+     vmware-rpctool "info-get guestinfo.userdata" || \
+     vmware-rpctool "info-get guestinfo.vendordata"; } >/dev/null 2>&1; then
    exit 0
 fi
 


### PR DESCRIPTION
Fixes #18

`vmware-rpctool` doesn't hang when called repeatedly and is generally faster than `vmtoolsd`.
According to https://github.com/vmware/open-vm-tools/issues/377 it should be save to replace it.

Alternatively a fallback could be implemented in case `vmware-rpctool` is not available but all distros should include it as well.

I have not tested this in our environment yet, will do that tomorrow.