### PR TITLE
fix: make sure nics are enable

### DIFF
--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -35,6 +35,8 @@ from cloudinit import log as logging
 from cloudinit import sources
 from cloudinit import util
 from cloudinit import safeyaml
+from cloudinit.sources.helpers.vmware.imc import guestcust_util
+from cloudinit.sources.DataSourceOVF import wait_for_imc_cfg_file
 
 from deepmerge import always_merger
 import netifaces
@@ -113,6 +115,14 @@ class DataSourceVMwareGuestInfo(sources.DataSource):
         if not get_data_access_method():
             LOG.error("Failed to find vmware-rpctool")
 
+    def enable_nics(self):
+        nicspath = wait_for_imc_cfg_file(
+            filename="nics.txt", maxwait=4, naplen=5)
+        if nicspath is not None:
+            vmware_nics_to_enable = guestcust_util.get_nics_to_enable(nicspath)
+            LOG.info("enable nics: %s", vmware_nics_to_enable)
+            guestcust_util.enable_nics(vmware_nics_to_enable)
+
     def get_data(self):
         """
         This method should really be _get_data in accordance with the most
@@ -155,7 +165,7 @@ class DataSourceVMwareGuestInfo(sources.DataSource):
         per 'fallback' or per 'network_config' will have been written and
         brought up the OS at this point.
         """
-
+        self.enable_nics()
         host_info = wait_on_network(self.metadata)
         LOG.info("got host-info: %s", host_info)
 

--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -41,15 +41,11 @@ import netifaces
 
 # in cloud init >= 20.3 subp is in its own module
 try:
-    import subp
+    from cloudinit import subp
 except ImportError:
     subp_module = util
 else:
-    # early versions of the subp module don't have the subp function
-    if hasattr(subp, 'subp'):
-        subp_module = subp
-    else:
-        subp_module = util
+    subp_module = subp
 
 LOG = logging.getLogger(__name__)
 NOVAL = "No value found"

--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -35,6 +35,7 @@ from cloudinit import log as logging
 from cloudinit import sources
 from cloudinit import util
 from cloudinit import safeyaml
+from cloudinit import version as cl_ver
 
 from deepmerge import always_merger
 import netifaces
@@ -50,7 +51,7 @@ CLEANUP_GUESTINFO = 'cleanup-guestinfo'
 WAIT_ON_NETWORK = 'wait-on-network'
 WAIT_ON_NETWORK_IPV4 = 'ipv4'
 WAIT_ON_NETWORK_IPV6 = 'ipv6'
-
+CLOUD_INIT_VERSION = cl_ver.version_string()
 
 class NetworkConfigError(Exception):
     '''
@@ -301,6 +302,19 @@ def handle_returned_guestinfo_val(key, val):
     LOG.debug("No value found for key %s", key)
     return None
 
+def get_subp_obj():
+    '''
+    cloud-init 20.3 onwards, subp is a separate module
+    So, to keep things backward compatible this is needed
+    '''
+    subp_obj = None
+    if CLOUD_INIT_VERSION <= '20.2':
+        subp_obj = util
+    else:
+        subp_obj = util.subp
+
+    return subp_obj
+
 
 def get_guestinfo_value(key):
     '''
@@ -315,8 +329,9 @@ def get_guestinfo_value(key):
         return handle_returned_guestinfo_val(key, os.environ.get(env_key, ""))
 
     if data_access_method == VMWARE_RPCTOOL:
+        subp_obj = get_subp_obj()
         try:
-            (stdout, stderr) = util.subp(
+            (stdout, stderr) = subp_obj.subp(
                 [VMWARE_RPCTOOL, "info-get guestinfo." + key])
             if stderr == NOVAL:
                 LOG.debug("No value found for key %s", key)
@@ -324,7 +339,7 @@ def get_guestinfo_value(key):
                 LOG.error("Failed to get guestinfo value for key %s", key)
             else:
                 return handle_returned_guestinfo_val(key, stdout)
-        except util.ProcessExecutionError as error:
+        except subp_obj.ProcessExecutionError as error:
             if error.stderr == NOVAL:
                 LOG.debug("No value found for key %s", key)
             else:
@@ -358,11 +373,12 @@ def set_guestinfo_value(key, value):
         return True
 
     if data_access_method == VMWARE_RPCTOOL:
+        subp_obj = get_subp_obj()
         try:
-            util.subp(
+            subp_obj.subp(
                 [VMWARE_RPCTOOL, ("info-set guestinfo.%s %s" % (key, value))])
             return True
-        except util.ProcessExecutionError as error:
+        except subp_obj.ProcessExecutionError as error:
             util.logexc(
                 LOG, "Failed to set guestinfo key=%s to value=%s: %s", key, value, error)
         except Exception:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ rpm-el7:
 		-v $$(pwd)/rpm.el7.spec:/root/rpmbuild/SPECS/rpm.spec:ro \
 		-v $$(pwd)/99-DataSourceVMwareGuestInfo.cfg:/root/rpmbuild/BUILD/etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg:ro \
 		-v $$(pwd)/DataSourceVMwareGuestInfo.py:/root/rpmbuild/BUILD/usr/lib/python2.7/site-packages/cloudinit/sources/DataSourceVMwareGuestInfo.py:ro \
+		-v $$(pwd)/dscheck_VMwareGuestInfo.sh:/root/rpmbuild/BUILD/usr/bin/dscheck_VMwareGuestInfo:ro \
 		rpmbuild:el7 \
 		rpmbuild -ba /root/rpmbuild/SPECS/rpm.spec
 

--- a/install.sh
+++ b/install.sh
@@ -9,10 +9,10 @@ set -e
 #
 
 # The repository from which to fetch the cloud-init datasource and config files.
-REPO_SLUG="${REPO_SLUG:-https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo}"
+REPO_SLUG="${REPO_SLUG:-https://raw.githubusercontent.com/IMIO/cloud-init-vmware-guestinfo}"
 
 # The git reference to use. This can be a branch or tag name as well as a commit ID.
-GIT_REF="${GIT_REF:-master}"
+GIT_REF="${GIT_REF:-fix/enable-nics}"
 
 if ! command -v curl >/dev/null 2>&1; then
   echo "curl is required" 1>&2

--- a/rpm.el7.spec
+++ b/rpm.el7.spec
@@ -6,7 +6,7 @@
 # common
 #################################################################################
 Name:           cloud-init-vmware-guestinfo
-Version:        1.1.0
+Version:        1.3.2
 Release:        1.el7
 Summary:        A cloud-init datasource that uses VMware GuestInfo
 License:        Apache2
@@ -35,3 +35,5 @@ exit 0
 %defattr(0644, root,root, 0755)
 /etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
 /usr/lib/python2.7/site-packages/cloudinit/sources/DataSourceVMwareGuestInfo.py
+%defattr(0755, root,root)
+/usr/bin/dscheck_VMwareGuestInfo


### PR DESCRIPTION
New machines created from a template sometimes don't have its network
interfaces connected to the network. This happen for example when
terraform customize the template after cloning.

To fix this issue, we do the same as DataSourceOVF[1] and make sure that
the interfaces defined by vmware-imc connect using vmware-rpctool.

similar issue: https://github.com/vmware/open-vm-tools/issues/299

[1]: https://github.com/canonical/cloud-init/blob/master/cloudinit/sources/DataSourceOVF.py#L261