### PR TITLE
Add a SPEC file for EL8

### DIFF
--- a/Dockerfile.rpmbuild
+++ b/Dockerfile.rpmbuild
@@ -1,2 +1,5 @@
-FROM centos:7
+# The CentOS image is the base of this image.
+ARG CENTOS_IMAGE=centos:7
+
+FROM ${CENTOS_IMAGE}
 RUN yum install -y rpm-build

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,22 @@ rpm-el7:
 		rpmbuild:el7 \
 		rpmbuild -ba /root/rpmbuild/SPECS/rpm.spec
 
+rpm-el8:
+	@rm -fr rpmbuild/el8
+	@mkdir -p rpmbuild/el8/RPMS rpmbuild/el8/SPECS \
+	  rpmbuild/el8/SRPMS \
+	  rpmbuild/el8/BUILD/etc/cloud/cloud.cfg.d \
+	  rpmbuild/el8/BUILD/usr/lib/python3.6/site-packages/cloudinit/sources
+	docker build --build-arg="CENTOS_IMAGE=centos:8" -f Dockerfile.rpmbuild -t rpmbuild:el8 .
+	docker run --rm -it \
+		-v $$(pwd)/rpmmacros:/root/.rpmmacros:ro \
+		-v $$(pwd)/rpmbuild/el8:/root/rpmbuild \
+		-v $$(pwd)/rpm.el8.spec:/root/rpmbuild/SPECS/rpm.spec:ro \
+		-v $$(pwd)/99-DataSourceVMwareGuestInfo.cfg:/root/rpmbuild/BUILD/99-DataSourceVMwareGuestInfo.cfg:ro \
+		-v $$(pwd)/DataSourceVMwareGuestInfo.py:/root/rpmbuild/BUILD/DataSourceVMwareGuestInfo.py:ro \
+		rpmbuild:el8 \
+		rpmbuild -ba /root/rpmbuild/SPECS/rpm.spec
+
 rpm: rpm-el7
 
 build: rpm

--- a/rpm.el8.spec
+++ b/rpm.el8.spec
@@ -1,0 +1,39 @@
+#
+# spec file for package cloud-init-vmware-guestinfo
+#
+
+#################################################################################
+# common
+#################################################################################
+Name:           cloud-init-vmware-guestinfo
+Version:        1.1.0
+Release:        1.el8
+Summary:        A cloud-init datasource that uses VMware GuestInfo
+License:        Apache2
+Requires:       cloud-init python3-netifaces
+Group:          Applications/System
+BuildArch:      noarch
+
+#################################################################################
+# specific
+#################################################################################
+%description
+A cloud-init datasource that uses VMware GuestInfo
+
+%prep
+
+%build
+
+%install
+mkdir -p %{buildroot}/etc/cloud/cloud.cfg.d
+mkdir -p %{buildroot}/usr/lib/python3.6/site-packages/cloudinit/sources
+cp 99-DataSourceVMwareGuestInfo.cfg %{buildroot}/etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+cp DataSourceVMwareGuestInfo.py %{buildroot}/usr/lib/python3.6/site-packages/cloudinit/sources/DataSourceVMwareGuestInfo.py
+
+%clean
+
+%files
+%defattr(0644, root,root, 0755)
+/etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+/usr/lib/python3.6/site-packages/cloudinit/sources/DataSourceVMwareGuestInfo.py
+/usr/lib/python3.6/site-packages/cloudinit/sources/__pycache__/DataSourceVMwareGuestInfo.*.pyc

--- a/rpm.el8.spec
+++ b/rpm.el8.spec
@@ -6,7 +6,7 @@
 # common
 #################################################################################
 Name:           cloud-init-vmware-guestinfo
-Version:        1.1.0
+Version:        1.2.0
 Release:        1.el8
 Summary:        A cloud-init datasource that uses VMware GuestInfo
 License:        Apache2


### PR DESCRIPTION
Add a SPEC file which can be used to build RPMs for CentOS and RHEL 8.

Based on request from @akutz to upstream changes in https://github.com/varesa/cloud-init-vmware-guestinfo/tree/el8 (19ee2293981e107c91fe0f1e76f1dd85774d209a)
This PR drops the README change (not relevant) and squashes the other two commits into one (with the other one being a minor fix)

Verified that this slightly modified version succesfully builds an RPM using https://github.com/akutz/cloud-init-vmware-guestinfo/commit/35f035151295537431cfa8f83f59728ce23fa330 and that the resulting package installs in a `centos:8` container

EDIT: Appended to include https://github.com/akutz/cloud-init-vmware-guestinfo/commit/35f035151295537431cfa8f83f59728ce23fa330 as well