### PR TITLE
Get subp object based on cloud-init version

### DIFF
--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -35,6 +35,7 @@ from cloudinit import log as logging
 from cloudinit import sources
 from cloudinit import util
 from cloudinit import safeyaml
+from cloudinit import version as cl_ver
 
 from deepmerge import always_merger
 import netifaces
@@ -50,7 +51,7 @@ CLEANUP_GUESTINFO = 'cleanup-guestinfo'
 WAIT_ON_NETWORK = 'wait-on-network'
 WAIT_ON_NETWORK_IPV4 = 'ipv4'
 WAIT_ON_NETWORK_IPV6 = 'ipv6'
-
+CLOUD_INIT_VERSION = cl_ver.version_string()
 
 class NetworkConfigError(Exception):
     '''
@@ -301,6 +302,19 @@ def handle_returned_guestinfo_val(key, val):
     LOG.debug("No value found for key %s", key)
     return None
 
+def get_subp_obj():
+    '''
+    cloud-init 20.3 onwards, subp is a separate module
+    So, to keep things backward compatible this is needed
+    '''
+    subp_obj = None
+    if CLOUD_INIT_VERSION <= '20.2':
+        subp_obj = util
+    else:
+        subp_obj = util.subp
+
+    return subp_obj
+
 
 def get_guestinfo_value(key):
     '''
@@ -315,8 +329,9 @@ def get_guestinfo_value(key):
         return handle_returned_guestinfo_val(key, os.environ.get(env_key, ""))
 
     if data_access_method == VMWARE_RPCTOOL:
+        subp_obj = get_subp_obj()
         try:
-            (stdout, stderr) = util.subp(
+            (stdout, stderr) = subp_obj.subp(
                 [VMWARE_RPCTOOL, "info-get guestinfo." + key])
             if stderr == NOVAL:
                 LOG.debug("No value found for key %s", key)
@@ -324,7 +339,7 @@ def get_guestinfo_value(key):
                 LOG.error("Failed to get guestinfo value for key %s", key)
             else:
                 return handle_returned_guestinfo_val(key, stdout)
-        except util.ProcessExecutionError as error:
+        except subp_obj.ProcessExecutionError as error:
             if error.stderr == NOVAL:
                 LOG.debug("No value found for key %s", key)
             else:
@@ -358,11 +373,12 @@ def set_guestinfo_value(key, value):
         return True
 
     if data_access_method == VMWARE_RPCTOOL:
+        subp_obj = get_subp_obj()
         try:
-            util.subp(
+            subp_obj.subp(
                 [VMWARE_RPCTOOL, ("info-set guestinfo.%s %s" % (key, value))])
             return True
-        except util.ProcessExecutionError as error:
+        except subp_obj.ProcessExecutionError as error:
             util.logexc(
                 LOG, "Failed to set guestinfo key=%s to value=%s: %s", key, value, error)
         except Exception:


### PR DESCRIPTION
cloud-init >= 20.3, subp is a seperate module.
So, data source should be modified accordingly. If someoone is using
guestinfo data source with cloud-init <=20.2 we should not break things.

This patch takes care of the above things.
Tested on Photon 3.0 VM with Photon OS using package test scripts.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>