### PR TITLE
Ipaddress Unicode Error

### DIFF
--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -575,7 +575,7 @@ def is_valid_ip_addr(val):
     """
     addr = None
     try:
-        addr = ipaddress.ip_address(unicode(val, "utf-8"))
+        addr = ipaddress.ip_address(val.encode("utf-8"))
     except:
         return False
     if addr.is_link_local or addr.is_loopback or addr.is_unspecified:

--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -575,7 +575,10 @@ def is_valid_ip_addr(val):
     """
     addr = None
     try:
-        addr = ipaddress.ip_address(val.encode("utf-8"))
+        try:
+            addr = ipaddress.ip_address(val)
+        except ipaddress.AddressValueError:
+            addr = ipaddress.ip_address(val.encode('utf-8'))
     except:
         return False
     if addr.is_link_local or addr.is_loopback or addr.is_unspecified:

--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -575,7 +575,7 @@ def is_valid_ip_addr(val):
     """
     addr = None
     try:
-        addr = ipaddress.ip_address(val)
+        addr = ipaddress.ip_address(unicode(val, "utf-8"))
     except:
         return False
     if addr.is_link_local or addr.is_loopback or addr.is_unspecified:


### PR DESCRIPTION
On some systems, the following error occurs resulting in cloud-init never resolving:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/ipaddress.py", line 163, in ip_address
    ' a unicode object?' % address)
ipaddress.AddressValueError: '172.16.4.144' does not appear to be an IPv4 or IPv6 address. Did you pass in a bytes (str in Python 2) instead of a unicode object?
```