### PR TITLE
Remove deepmerge dependency

### DIFF
--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -36,7 +36,6 @@ from cloudinit import sources
 from cloudinit import util
 from cloudinit import safeyaml
 
-from deepmerge import always_merger
 import netifaces
 
 # from cloud-init >= 20.3 subp is in its own module
@@ -57,6 +56,7 @@ CLEANUP_GUESTINFO = 'cleanup-guestinfo'
 WAIT_ON_NETWORK = 'wait-on-network'
 WAIT_ON_NETWORK_IPV4 = 'ipv4'
 WAIT_ON_NETWORK_IPV6 = 'ipv6'
+
 
 class NetworkConfigError(Exception):
     '''
@@ -165,7 +165,7 @@ class DataSourceVMwareGuestInfo(sources.DataSource):
         # Ensure the metadata gets updated with information about the
         # host, including the network interfaces, default IP addresses,
         # etc.
-        self.metadata = always_merger.merge(self.metadata, host_info)
+        self.metadata = merge_dicts(self.metadata, host_info)
 
         # Persist the instance data for versions of cloud-init that support
         # doing so. This occurs here rather than in the get_data call in
@@ -306,6 +306,7 @@ def handle_returned_guestinfo_val(key, val):
         return val
     LOG.debug("No value found for key %s", key)
     return None
+
 
 def get_guestinfo_value(key):
     '''
@@ -725,14 +726,49 @@ def get_data_access_method():
     return None
 
 
+_MERGE_STRATEGY_ENV_VAR = 'CLOUD_INIT_VMWARE_GUEST_INFO_MERGE_STRATEGY'
+_MERGE_STRATEGY_DEEPMERGE = 'deepmerge'
+
+
+def merge_dicts(a, b):
+    merge_strategy = os.getenv(_MERGE_STRATEGY_ENV_VAR)
+    if merge_strategy == _MERGE_STRATEGY_DEEPMERGE:
+        try:
+            LOG.info('merging dictionaries with deepmerge strategy')
+            return merge_dicts_with_deep_merge(a, b)
+        except Exception as err:
+            LOG.error("deep merge failed: %s" % err)
+    LOG.info('merging dictionaries with stdlib strategy')
+    return merge_dicts_with_stdlib(a, b)
+
+
+def merge_dicts_with_deep_merge(a, b):
+    from deepmerge import always_merger
+    return always_merger.merge(a, b)
+
+
+def merge_dicts_with_stdlib(a, b):
+    for key, value in a.items():
+        if isinstance(value, dict):
+            node = b.setdefault(key, {})
+            merge_dicts_with_stdlib(value, node)
+        else:
+            b[key] = value
+    return b
+
+
 def main():
     '''
     Executed when this file is used as a program.
     '''
+    try:
+        logging.setupBasicLogging()
+    except Exception:
+        pass
     metadata = {'wait-on-network': {'ipv4': True, 'ipv6': "false"},
                 'network': {'config': {'dhcp': True}}}
     host_info = wait_on_network(metadata)
-    metadata = always_merger.merge(metadata, host_info)
+    metadata = merge_dicts(metadata, host_info)
     print(util.json_dumps(metadata))
 
 

--- a/install.sh
+++ b/install.sh
@@ -59,10 +59,11 @@ else
 fi
 echo "using python ${PYTHON_VERSION}"
 
-# The python modules deepmerge and netifaces are required. If they are
-# already installed, an assumption is made they are the correct versions.
-# Otherwise an attempt is made to install them with pip.
-if [ -z "$(get_py_mod_dir deepmerge)" ] || [ -z "$(get_py_mod_dir netifaces)" ]; then
+# The following modules are required:
+#   * netifaces
+# If a module is already installed then it is assumed to be compatible.
+# Otherwise an attempt is made to install the module with pip.
+if [ -z "$(get_py_mod_dir netifaces)" ]; then
   echo "installing requirements"
   if [ -z "$(get_py_mod_dir pip)" ]; then
     echo "pip is required" 1>&2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-deepmerge >= 0.0.5
 netifaces >= 0.10.9


### PR DESCRIPTION
# Overview

This patch removes the deepmerge module as a required dependency of this cloud-init datasource. There is still an option to use the `deepmerge` module if the environment variable `CLOUD_INIT_VMWARE_GUEST_INFO_MERGE_STRATEGY` is set to `deepmerge`. Otherwise a deep merge is performed with a recursive strategy using Python built-ins.

This does *not* remove the dependency on the `netifaces` module.

# Testing

The following test cases were executed to assert this works as designed:

| Python Version | Merge Strategy | Command | Results |
|---|---|---|---|
| 2.7.17 | `deepmerge` | `python2 DataSourceVMwareGuestInfo.py 1>p2-deepmerge.json` | ([link](https://gist.github.com/akutz/2bc95ef7887b653ddeed4c1bd5b2de14#file-p2-deepmerge-json)) |
|  | `stdlib`  | `python2 DataSourceVMwareGuestInfo.py 1>p2-stdlib.json` | ([link](https://gist.github.com/akutz/2bc95ef7887b653ddeed4c1bd5b2de14#file-p2-stdlib-json)) |
| 3.7.3 | `deepmerge` | `python3 DataSourceVMwareGuestInfo.py 1>p3-deepmerge.json` | ([link](https://gist.github.com/akutz/2bc95ef7887b653ddeed4c1bd5b2de14#file-p3-deepmerge-json)) |
|  | `stdlib`  | `python3 DataSourceVMwareGuestInfo.py 1>p3-stdlib.json` | ([link](https://gist.github.com/akutz/2bc95ef7887b653ddeed4c1bd5b2de14#file-p3-stdlib-json)) |

---

**Note**: The above commands will redirect the merged JSON into the specified file. However, the logger will emit a message to `stderr` on the console to indicate the selected merge strategy. This log entry will **not** be part of the contents written to the file. For example:

```bash
# stdlib merge strategy
$ python3 DataSourceVMwareGuestInfo.py 1>p3-stdlib.json
2020-09-22 18:43:47,701 - DataSourceVMwareGuestInfo.py[INFO]: merging dictionaries with stdlib strategy

# deepmerge strategy
$ CLOUD_INIT_VMWARE_GUEST_INFO_MERGE_STRATEGY=deepmerge \
  python3 DataSourceVMwareGuestInfo.py 1>p3-deepmerge.json
2020-09-22 18:44:24,219 - DataSourceVMwareGuestInfo.py[INFO]: merging dictionaries with deepmerge strategy
```

---

The following command will `diff` all permutations (I'm not inclined to figure out how to eliminate the repetition), and the result is no differences between any of the above files:

```bash
BASE_URL=https://gist.githubusercontent.com/akutz/2bc95ef7887b653ddeed4c1bd5b2de14/raw/bac0403b9675dfa86679adaf240335fda63bbac2 && \
for AB in {2..3}{a..b}-{2..3}{a..b}; do \
  A="${AB%-*}"; B="${AB#*-}"; \
  [ "${A}" != "${B}" ] || continue; \
  [ "${A}" == "2a" ] && f1="p2-deepmerge.json"; \
  [ "${A}" == "2b" ] && f1="p2-stdlib.json"; \
  [ "${A}" == "3a" ] && f1="p3-deepmerge.json"; \
  [ "${A}" == "3b" ] && f1="p3-stdlib.json"; \
  [ "${B}" == "2a" ] && f2="p2-deepmerge.json"; \
  [ "${B}" == "2b" ] && f2="p2-stdlib.json"; \
  [ "${B}" == "3a" ] && f2="p3-deepmerge.json"; \
  [ "${B}" == "3b" ] && f2="p3-stdlib.json"; \
  echo "diff ${f1} ${f2}"; \
  diff <(curl -sSL "${BASE_URL}/${f1}") <(curl -sSL "${BASE_URL}/${f2}"); \
done
```

Does anyone care to do some additional testing on this? Thank you!

cc @yvespp @powersj @sshedi 