### PR TITLE
Handle platform key in metadata

### DIFF
--- a/DataSourceVMwareGuestInfo.py
+++ b/DataSourceVMwareGuestInfo.py
@@ -166,6 +166,16 @@ class DataSourceVMwareGuestInfo(sources.DataSource):
         # host, including the network interfaces, default IP addresses,
         # etc.
         self.metadata = merge_dicts(self.metadata, host_info)
+        
+        # If the loaded metadata includes a platform key
+        # we use this is as self_platform otherwise it always
+        # defaults to dsname (see superclass property platform_type)
+        if self.metadata.get('platform', None) is not None:
+            # self._platform is not specifically referenced in superclass
+            # but mentioned this way in a comment so better safe than sorry
+            self._platform = self.metadata.get('platform')
+            # this one will be referenced by the superclass properties hasattr
+            self._platform_type = self.metadata.get('platform')     
 
         # Persist the instance data for versions of cloud-init that support
         # doing so. This occurs here rather than in the get_data call in


### PR DESCRIPTION
Hi,

according to the cloud-init docs the metadata key v1.platform should identify the cloud an instance is running on.
This is usally derived from the DataSource name (dsname.lower()) in the Datasource superclass if not set explicitly.

For our environment i would like to be able to set this by providing it through the data that i put into guestinfo.metadata.
This is because we have different VMware Environments that i would like to be able to differentiate between inside a virtual machine.

My change would allow us to provide a platform key through the metadata and have the Datasource present this correctly to cloud-init and persist this into the instance data.json

If no platform key is set by the user this will persist the v1.platform key as "vmwareguestinfo" as it did before...

kind regards,
Daniel