### PR TITLE
guestinfo.metadata can be YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The data source is configured by setting `guestinfo` properties on a VM's `extra
 
 | Property | Description |
 |----------|-------------|
-| `guestinfo.metadata` | A JSON string containing the cloud-init metadata. |
+| `guestinfo.metadata` | A YAML document containing the cloud-init metadata. |
 | `guestinfo.metadata.encoding` | The encoding type for `guestinfo.metadata`. |
 | `guestinfo.userdata` | A YAML document containing the cloud-init user data. |
 | `guestinfo.userdata.encoding` | The encoding type for `guestinfo.userdata`. |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The data source is configured by setting `guestinfo` properties on a VM's `extra
 
 | Property | Description |
 |----------|-------------|
-| `guestinfo.metadata` | A YAML document containing the cloud-init metadata. |
+| `guestinfo.metadata` | A YAML or JSON document containing the cloud-init metadata. |
 | `guestinfo.metadata.encoding` | The encoding type for `guestinfo.metadata`. |
 | `guestinfo.userdata` | A YAML document containing the cloud-init user data. |
 | `guestinfo.userdata.encoding` | The encoding type for `guestinfo.userdata`. |


### PR DESCRIPTION
This makes the documentation of this property:
- match the other properties, which also take YAML
- consistent with the example below, which uses YAML